### PR TITLE
Integrate planner-driven process list into main form

### DIFF
--- a/MainForm.Designer.cs
+++ b/MainForm.Designer.cs
@@ -1,9 +1,12 @@
-﻿namespace Planificador
+namespace Planificador
 {
     partial class MainForm
     {
-      
+        /// <summary>
+        ///  Required designer variable.
+        /// </summary>
         private System.ComponentModel.IContainer components = null;
+
         /// <summary>
         ///  Clean up any resources being used.
         /// </summary>
@@ -14,107 +17,113 @@
             {
                 components.Dispose();
             }
+
             base.Dispose(disposing);
         }
 
         #region Windows Form Designer generated code
 
-       
+        /// <summary>
+        ///  Required method for Designer support - do not modify
+        ///  the contents of this method with the code editor.
+        /// </summary>
         private void InitializeComponent()
         {
-            ListViewItem listViewItem1 = new ListViewItem(new string[] { "Descarga 1", "00:00", "00:00", "00:00", "00:00", "00:00", "00:00" }, -1);
-            ListViewItem listViewItem2 = new ListViewItem(new string[] { "Descarga 2", "00:03", "00:03", "00:03", "00:03", "00:03", "00:03" }, -1);
-            ListViewItem listViewItem3 = new ListViewItem(new string[] { "Descarga 3", "00:05", "00:05", "00:05", "00:05", "00:05", "00:05" }, -1);
-            listView1 = new ListView();
-            processHeader = new ColumnHeader();
-            arrivalHeader = new ColumnHeader();
-            durationHeader = new ColumnHeader();
-            startTimeHeader = new ColumnHeader();
-            endTimeHeader = new ColumnHeader();
-            waitTimeHeader = new ColumnHeader();
-            returnTimeHeader = new ColumnHeader();
-            SuspendLayout();
+            this.procesosListView = new System.Windows.Forms.ListView();
+            this.processHeader = new System.Windows.Forms.ColumnHeader();
+            this.arrivalHeader = new System.Windows.Forms.ColumnHeader();
+            this.durationHeader = new System.Windows.Forms.ColumnHeader();
+            this.startTimeHeader = new System.Windows.Forms.ColumnHeader();
+            this.endTimeHeader = new System.Windows.Forms.ColumnHeader();
+            this.waitTimeHeader = new System.Windows.Forms.ColumnHeader();
+            this.returnTimeHeader = new System.Windows.Forms.ColumnHeader();
+            this.SuspendLayout();
             // 
-            // listView1
+            // procesosListView
             // 
-            listView1.BorderStyle = BorderStyle.FixedSingle;
-            listView1.CheckBoxes = true;
-            listView1.Columns.AddRange(new ColumnHeader[] { processHeader, arrivalHeader, durationHeader, startTimeHeader, endTimeHeader, waitTimeHeader, returnTimeHeader });
-            listView1.Dock = DockStyle.Fill;
-            listView1.FullRowSelect = true;
-            listView1.GridLines = true;
-            listView1.HeaderStyle = ColumnHeaderStyle.Nonclickable;
-            listViewItem1.Checked = true;
-            listViewItem1.StateImageIndex = 1;
-            listViewItem2.StateImageIndex = 0;
-            listViewItem3.StateImageIndex = 0;
-            listView1.Items.AddRange(new ListViewItem[] { listViewItem1, listViewItem2, listViewItem3 });
-            listView1.Location = new Point(0, 0);
-            listView1.Name = "listView1";
-            listView1.ShowGroups = false;
-            listView1.Size = new Size(800, 450);
-            listView1.TabIndex = 0;
-            listView1.UseCompatibleStateImageBehavior = false;
-            listView1.View = View.Details;
-            listView1.ItemCheck += listView1_ItemCheck;
+            this.procesosListView.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.procesosListView.CheckBoxes = true;
+            this.procesosListView.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.processHeader,
+            this.arrivalHeader,
+            this.durationHeader,
+            this.startTimeHeader,
+            this.endTimeHeader,
+            this.waitTimeHeader,
+            this.returnTimeHeader});
+            this.procesosListView.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.procesosListView.FullRowSelect = true;
+            this.procesosListView.GridLines = true;
+            this.procesosListView.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
+            this.procesosListView.Location = new System.Drawing.Point(0, 0);
+            this.procesosListView.MultiSelect = false;
+            this.procesosListView.Name = "procesosListView";
+            this.procesosListView.ShowGroups = false;
+            this.procesosListView.Size = new System.Drawing.Size(800, 450);
+            this.procesosListView.TabIndex = 0;
+            this.procesosListView.UseCompatibleStateImageBehavior = false;
+            this.procesosListView.View = System.Windows.Forms.View.Details;
             // 
             // processHeader
             // 
-            processHeader.Text = "Proceso";
-            processHeader.Width = 250;
+            this.processHeader.Text = "Proceso";
+            this.processHeader.Width = 220;
             // 
             // arrivalHeader
             // 
-            arrivalHeader.Text = "Tiempo de llegada";
-            arrivalHeader.Width = 140;
+            this.arrivalHeader.Text = "Llegada";
+            this.arrivalHeader.Width = 90;
             // 
             // durationHeader
             // 
-            durationHeader.Text = "Duración";
-            durationHeader.Width = 75;
+            this.durationHeader.Text = "Duración";
+            this.durationHeader.Width = 90;
             // 
             // startTimeHeader
             // 
-            startTimeHeader.Text = "Inicio";
+            this.startTimeHeader.Text = "Inicio";
+            this.startTimeHeader.Width = 90;
             // 
             // endTimeHeader
             // 
-            endTimeHeader.Text = "Fin";
+            this.endTimeHeader.Text = "Fin";
+            this.endTimeHeader.Width = 90;
             // 
             // waitTimeHeader
             // 
-            waitTimeHeader.Text = "Espera";
+            this.waitTimeHeader.Text = "Espera";
+            this.waitTimeHeader.Width = 90;
             // 
             // returnTimeHeader
             // 
-            returnTimeHeader.Text = "Tiempo de retorno";
-            returnTimeHeader.Width = 140;
+            this.returnTimeHeader.Text = "Retorno";
+            this.returnTimeHeader.Width = 90;
             // 
             // MainForm
             // 
-            AutoScaleDimensions = new SizeF(8F, 20F);
-            AutoScaleMode = AutoScaleMode.Font;
-            ClientSize = new Size(800, 450);
-            Controls.Add(listView1);
-            FormBorderStyle = FormBorderStyle.FixedDialog;
-            MaximizeBox = false;
-            MinimizeBox = false;
-            Name = "MainForm";
-            StartPosition = FormStartPosition.CenterScreen;
-            Text = "Planificador de procesos PEPSI";
-            Shown += MainForm_Shown;
-            ResumeLayout(false);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(800, 450);
+            this.Controls.Add(this.procesosListView);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "MainForm";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "Planificador de procesos PEPSI";
+            this.Shown += new System.EventHandler(this.MainForm_Shown);
+            this.ResumeLayout(false);
         }
 
         #endregion
 
-        private ListView listView1;
-        private ColumnHeader processHeader;
-        private ColumnHeader arrivalHeader;
-        private ColumnHeader durationHeader;
-        private ColumnHeader startTimeHeader;
-        private ColumnHeader endTimeHeader;
-        private ColumnHeader waitTimeHeader;
-        private ColumnHeader returnTimeHeader;
+        private System.Windows.Forms.ListView procesosListView;
+        private System.Windows.Forms.ColumnHeader processHeader;
+        private System.Windows.Forms.ColumnHeader arrivalHeader;
+        private System.Windows.Forms.ColumnHeader durationHeader;
+        private System.Windows.Forms.ColumnHeader startTimeHeader;
+        private System.Windows.Forms.ColumnHeader endTimeHeader;
+        private System.Windows.Forms.ColumnHeader waitTimeHeader;
+        private System.Windows.Forms.ColumnHeader returnTimeHeader;
     }
 }

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -1,62 +1,48 @@
+using System;
 using System.Collections.Generic;
+using System.Windows.Forms;
 
 namespace Planificador
 {
     public partial class MainForm : Form
     {
-        bool initialized = false;
-        bool sentFromApplication = false;
+        private readonly Planificador _planificador;
 
         public MainForm()
         {
             InitializeComponent();
-        }
 
-        private void listView1_ItemCheck(object sender, ItemCheckEventArgs e)
-        {
-            if (initialized && !sentFromApplication)
+            var procesos = new List<Proceso>
             {
-                e.NewValue = e.CurrentValue;
-                sentFromApplication = false;
-            }
+                new("Descarga 1", 0, 5),
+                new("Descarga 2", 3, 2),
+                new("Descarga 3", 5, 4)
+            };
+
+            _planificador = new Planificador(procesos);
         }
 
         private void MainForm_Shown(object sender, EventArgs e)
         {
-            initialized = true;
-            CargarProcesos();  // 👉 al mostrarse el form, carga los procesos
+            MostrarProcesos();
         }
 
-        private void CargarProcesos()
+        private void MostrarProcesos()
         {
-            // 🔹 Aquí defines tus procesos de ejemplo
-            var lista = new List<Proceso>
-            {
-                new Proceso("Descarga 1", 0, 5),
-                new Proceso("Descarga 2", 3, 2),
-                new Proceso("Descarga 3", 5, 4)
-            };
+            procesosListView.BeginUpdate();
+            procesosListView.Items.Clear();
 
-            // 🔹 Pasar la lista al planificador
-            var planificador = new Planificador(lista);
-            var resultado = planificador.Ejecutar();
-
-            // 🔹 Mostrar resultados en el ListView
-            listView1.Items.Clear();
-            foreach (var p in resultado)
+            foreach (var fila in _planificador.ObtenerResultadosFormateados())
             {
-                var item = new ListViewItem(new string[]
+                var item = new ListViewItem(fila)
                 {
-                    p.Nombre,
-                    p.TiempoLlegada.ToString(),
-                    p.Duracion.ToString(),
-                    p.TiempoInicio.ToString(),
-                    p.TiempoFin.ToString(),
-                    p.TiempoEspera.ToString(),
-                    p.TiempoRetorno.ToString()
-                });
-                listView1.Items.Add(item);
+                    Checked = true
+                };
+
+                procesosListView.Items.Add(item);
             }
+
+            procesosListView.EndUpdate();
         }
     }
 }

--- a/Planificador.cs
+++ b/Planificador.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -5,34 +6,57 @@ namespace Planificador
 {
     public class Planificador
     {
-        private List<Proceso> procesos;
+        private readonly List<Proceso> procesos;
 
-        public Planificador(List<Proceso> listaProcesos)
+        public Planificador(IEnumerable<Proceso> listaProcesos)
         {
             procesos = listaProcesos
-                        .OrderBy(p => p.TiempoLlegada) // ordenar por llegada
-                        .ToList();
+                .OrderBy(p => p.TiempoLlegada)
+                .ToList();
         }
 
-        public List<Proceso> Ejecutar()
+        public IReadOnlyList<Proceso> Ejecutar()
         {
             int tiempoActual = 0;
 
-            foreach (var p in procesos)
+            foreach (var proceso in procesos)
             {
-                // Si el proceso llega después del tiempo actual, el CPU espera
-                if (tiempoActual < p.TiempoLlegada)
-                    tiempoActual = p.TiempoLlegada;
+                if (tiempoActual < proceso.TiempoLlegada)
+                {
+                    tiempoActual = proceso.TiempoLlegada;
+                }
 
-                p.TiempoInicio = tiempoActual;
-                p.TiempoFin = tiempoActual + p.Duracion;
-                p.TiempoEspera = p.TiempoInicio - p.TiempoLlegada;
-                p.TiempoRetorno = p.TiempoFin - p.TiempoLlegada;
+                proceso.TiempoInicio = tiempoActual;
+                proceso.TiempoFin = tiempoActual + proceso.Duracion;
+                proceso.TiempoEspera = proceso.TiempoInicio - proceso.TiempoLlegada;
+                proceso.TiempoRetorno = proceso.TiempoFin - proceso.TiempoLlegada;
 
-                tiempoActual = p.TiempoFin;
+                tiempoActual = proceso.TiempoFin;
             }
 
             return procesos;
+        }
+
+        public IEnumerable<string[]> ObtenerResultadosFormateados()
+        {
+            Ejecutar();
+
+            return procesos.Select(proceso => new[]
+            {
+                proceso.Nombre,
+                FormatearTiempo(proceso.TiempoLlegada),
+                FormatearTiempo(proceso.Duracion),
+                FormatearTiempo(proceso.TiempoInicio),
+                FormatearTiempo(proceso.TiempoFin),
+                FormatearTiempo(proceso.TiempoEspera),
+                FormatearTiempo(proceso.TiempoRetorno)
+            });
+        }
+
+        private static string FormatearTiempo(int minutos)
+        {
+            var tiempo = TimeSpan.FromMinutes(minutos);
+            return $"{(int)tiempo.TotalHours:00}:{tiempo.Minutes:00}";
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace the hardcoded designer list view with a dedicated procesosListView configured for runtime data
- instantiate the planner in the main form and populate the list view using the scheduler results
- extend the planner to format process metrics for presentation

## Testing
- Not run (dotnet CLI is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68df559cb2e4832e8088cc2e595757ec