### PR TITLE
Implementar planificación Shortest Remaining Time

### DIFF
--- a/MainForm.cs
+++ b/MainForm.cs
@@ -12,7 +12,6 @@ namespace Planificador
         private readonly Dictionary<Proceso, ListViewItem> _itemsPorProceso = new();
         private Thread? _hiloSimulacion;
         private const int MilisegundosPorMinuto = 1000;
-        private const int Quantum = 3;
 
         public MainForm()
         {
@@ -32,7 +31,7 @@ namespace Planificador
                 new("backup_celular_mi_ex_2015.zip", 10, 9),
                 new("Presentacion_Final_DE_VERDAD.pptx", 11, 4)
             };
-            _planificador = new Planificador(procesos, Quantum);
+            _planificador = new Planificador(procesos);
             _procesos = _planificador.Ejecutar();
         }
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Planificador de procesos Round Robin
+# Planificador de procesos Shortest Remaining Time
 
-Aplicación WinForms que simula la planificación de un conjunto de procesos utilizando el algoritmo Round Robin.
+Aplicación WinForms que simula la planificación de un conjunto de procesos utilizando el algoritmo Shortest Remaining Time (SRT).
 
-* Admite una cola dinámica de procesos ordenada por llegada y ejecutados con un quantum configurable.
+* Admite una cola dinámica de procesos ordenada por llegada y priorizados por el tiempo restante más corto, con reasignación en cada llegada.
 * Muestra en tiempo real los estados de cada proceso (bloqueado, listo, en ejecución y terminado) durante la simulación.
 * Calcula para cada proceso los tiempos de espera, respuesta y retorno.
 * Genera estadísticas agregadas (mínimo, máximo, promedio y desviación estándar) para los tiempos de respuesta y de retorno.


### PR DESCRIPTION
## Summary
- sustituir la planificación Round Robin por una implementación de Shortest Remaining Time basada en prioridad del tiempo restante
- ajustar la inicialización de la interfaz y la documentación para reflejar el nuevo algoritmo

## Testing
- `dotnet build` *(no disponible en el entorno de ejecución)*

------
https://chatgpt.com/codex/tasks/task_e_68ec8a8178e0832eb5c197c43bc03f35